### PR TITLE
move to rust 2021

### DIFF
--- a/laboratory/Cargo.toml
+++ b/laboratory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "laboratory"
 version = "0.1.0"
 authors = ["kianenigma <kian.peymani@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 

--- a/laboratory/remote-ext-elections-phragmen/Cargo.toml
+++ b/laboratory/remote-ext-elections-phragmen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "remote-ext-elections-phragmen"
 version = "0.1.0"
 authors = ["kianenigma <kian.peymani@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # This cannot be in the global workspace due to dependency gitch.
 [workspace]

--- a/laboratory/remote-ext-phragmms/Cargo.toml
+++ b/laboratory/remote-ext-phragmms/Cargo.toml
@@ -2,7 +2,7 @@
 name = "remote-ext-phragmms"
 version = "0.1.0"
 authors = ["kianenigma <kian.peymani@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # This cannot be in the global workspace due to dependency gitch.
 [workspace]

--- a/migration-dry-run/Cargo.toml
+++ b/migration-dry-run/Cargo.toml
@@ -2,7 +2,7 @@
 name = "migration-dry-run"
 version = "0.1.0"
 authors = ["kianenigma <kian.peymani@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/migration-dry-run/rustfmt.toml
+++ b/migration-dry-run/rustfmt.toml
@@ -11,4 +11,4 @@ use_small_heuristics = "Max"
 
 trailing_comma = "Vertical"
 
-edition = "2018"
+edition = "2021"

--- a/offline-election/Cargo.toml
+++ b/offline-election/Cargo.toml
@@ -2,7 +2,7 @@
 name = "offline-election"
 version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/polkadot-mock-runtime/Cargo.toml
+++ b/polkadot-mock-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mock-runtime"
 version = "0.1.0"
 authors = ["kianenigma <kian.peymani@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 

--- a/remote-externalities/Cargo.toml
+++ b/remote-externalities/Cargo.toml
@@ -2,7 +2,7 @@
 name = "remote-externalities"
 version = "0.1.0"
 authors = ["kianenigma <kian.peymani@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 jsonrpsee-types = { git = "https://github.com/paritytech/jsonrpsee", rev = "4025c0f67298ab7216214feac4e2c29ca9b24710" }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -11,4 +11,4 @@ use_small_heuristics = "Max"
 
 trailing_comma = "Vertical"
 
-edition = "2018"
+edition = "2021"

--- a/staking-miner/Cargo.toml
+++ b/staking-miner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "staking-miner"
 version = "0.1.0"
 authors = ["kianenigma <kian.peymani@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 

--- a/sub-du/Cargo.toml
+++ b/sub-du/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sub-du"
 version = "0.1.0"
 authors = ["kianenigma <kian.peymani@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/sub-storage/Cargo.toml
+++ b/sub-storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sub-storage"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 [dependencies]

--- a/sub-tokens/Cargo.toml
+++ b/sub-tokens/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sub-tokens"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 separator = "0.4.1"


### PR DESCRIPTION
Confirmed to build locally on Ubuntu 20.04.3 LTS:
```
rustc 1.56.1 (59eed8a2a 2021-11-01)
rustc 1.58.0-nightly (e90c5fbbc 2021-11-12)
```

## Test Failures:

`cargo test --release`

```
running 8 tests
test tests::can_get_all_storage_ws ... FAILED
test tests::get_storage_size_works_map ... FAILED
test tests::storage_map_read_works ... FAILED
test tests::storage_value_read_works ... FAILED
test tests::kusama_1832 ... FAILED
test tests::get_storage_size_works_value ... FAILED
test tests::get_const_works ... FAILED
test tests::can_get_all_storage_http ... FAILED

failures:

---- tests::can_get_all_storage_ws stdout ----
thread 'tests::can_get_all_storage_ws' panicked at 'not yet implemented', sub-storage/src/lib.rs:420:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::get_storage_size_works_map stdout ----
thread 'tests::get_storage_size_works_map' panicked at 'called `Result::unwrap()` on an `Err` value: TransportError(Connect(Io(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))', sub-storage/src/lib.rs:43:56

---- tests::storage_map_read_works stdout ----
thread 'tests::storage_map_read_works' panicked at 'called `Result::unwrap()` on an `Err` value: TransportError(Connect(Io(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))', sub-storage/src/lib.rs:43:56

---- tests::storage_value_read_works stdout ----
thread 'tests::storage_value_read_works' panicked at 'called `Result::unwrap()` on an `Err` value: TransportError(Connect(Io(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))', sub-storage/src/lib.rs:43:56

---- tests::kusama_1832 stdout ----
thread 'tests::kusama_1832' panicked at 'called `Result::unwrap()` on an `Err` value: TransportError(Connect(Io(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))', sub-storage/src/lib.rs:43:56

---- tests::get_storage_size_works_value stdout ----
thread 'tests::get_storage_size_works_value' panicked at 'called `Result::unwrap()` on an `Err` value: TransportError(Connect(Io(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))', sub-storage/src/lib.rs:43:56

---- tests::get_const_works stdout ----
thread 'tests::get_const_works' panicked at 'called `Result::unwrap()` on an `Err` value: TransportError(Connect(Io(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))', sub-storage/src/lib.rs:43:56

---- tests::can_get_all_storage_http stdout ----
thread 'tests::can_get_all_storage_http' panicked at 'called `Result::unwrap()` on an `Err` value: TransportError(Connect(Io(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))', sub-storage/src/lib.rs:43:56


failures:
    tests::can_get_all_storage_http
    tests::can_get_all_storage_ws
    tests::get_const_works
    tests::get_storage_size_works_map
    tests::get_storage_size_works_value
    tests::kusama_1832
    tests::storage_map_read_works
    tests::storage_value_read_works

test result: FAILED. 0 passed; 8 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass '-p sub-storage --lib'
``` 